### PR TITLE
Adding a check of attach method in jquery plugin

### DIFF
--- a/src/js/freezeframe.js
+++ b/src/js/freezeframe.js
@@ -348,17 +348,22 @@ $.fn.freezeframe = function(_options) {
   var ff = new freezeframe(_options);
 
   ff.images = this;
-
-  ff.setup().attach();
-
-  var self = this;
-  var methods = ['trigger', 'release'];
-  methods.forEach(function(method) {
-    self[method] = function() {
-      ff[method](self.selector);
-      return self;
-    };
-  });
-
+  
+  var setup = ff.setup();
+  
+  if(typeof setup.attach !== 'undefined')
+  {
+      ff.setup().attach();
+    
+      var self = this;
+      var methods = ['trigger', 'release'];
+      methods.forEach(function(method) {
+        self[method] = function() {
+          ff[method](self.selector);
+          return self;
+        };
+      });
+  }
+  
   return this;
 };


### PR DESCRIPTION
Hello,

there is a problem with the jquery plugin,

setup() can sometimes be null if no images are found,
so we need to check that attach is not undefined before calling it.

thanks.