### PR TITLE
Add support for fractional width and height values

### DIFF
--- a/packages/freezeframe/src/index.ts
+++ b/packages/freezeframe/src/index.ts
@@ -124,8 +124,12 @@ class Freezeframe {
   private _process(freeze: Freeze): Promise<Freeze> {
     return new Promise((resolve) => {
       const { $canvas, $image, $container } = freeze;
-      const { clientWidth, clientHeight } = $image;
+      const { width, height } = $image.getClientRects()[0];
+      const clientWidth = Math.ceil(width);
+      const clientHeight = Math.ceil(height);
 
+      $canvas.style.width =  `${width}px`;
+      $canvas.style.height = `${height}px`;
       $canvas.setAttribute('width', clientWidth.toString());
       $canvas.setAttribute('height', clientHeight.toString());
 


### PR DESCRIPTION
I just found the demo page on an article and noticed the image jumps a bit when pausing, so I decided to look into it and found that the way the width and height are read is what a property that only supports integers. With responsive widths it's common to have floating point numbers, so `getClientRects()` has a much cleaner result. Hope this helps, I'll definitely be trying this library if I ever have a gif somewhere (:

~~Edit: just noticed this doesn't yet fully fix it on the 2nd example on the demo page, maybe inline-styles should be used to set the dimensions of the canvas?~~ implemented and hopefully works now, also added explanations [in the commit](https://github.com/ctrl-freaks/freezeframe.js/pull/90/commits/feb2098a752136f0723b8ba3fe31c24908f6c258)