### PR TITLE
Applied scale to canvas to prevent blurry images.

### DIFF
--- a/packages/freezeframe/src/index.ts
+++ b/packages/freezeframe/src/index.ts
@@ -124,11 +124,12 @@ class Freezeframe {
   private _process(freeze: Freeze): Promise<Freeze> {
     return new Promise((resolve) => {
       const { $canvas, $image, $container } = freeze;
+      const scale = devicePixelRatio;
       const { width, height } = $image.getClientRects()[0];
-      const clientWidth = Math.ceil(width);
-      const clientHeight = Math.ceil(height);
+      const clientWidth = Math.ceil(width * scale);
+      const clientHeight = Math.ceil(height * scale);
 
-      $canvas.style.width =  `${width}px`;
+      $canvas.style.width = `${width}px`;
       $canvas.style.height = `${height}px`;
       $canvas.setAttribute('width', clientWidth.toString());
       $canvas.setAttribute('height', clientHeight.toString());


### PR DESCRIPTION
Closes #158

Applies a scale on images with high device pixel ratio.

My computer has a device pixel ratio of 1.25, so a 24x24 image was being rendered onto 32x32. Consequently, the image was blurry.